### PR TITLE
Use Services global variable if possible

### DIFF
--- a/api/ResourceUrl/implementation.js
+++ b/api/ResourceUrl/implementation.js
@@ -25,7 +25,6 @@
   var { ExtensionUtils } = ChromeUtils.import(
     "resource://gre/modules/ExtensionUtils.jsm"
   );
-  var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
   var { ExtensionError } = ExtensionUtils;
 
   let resourceUrls = new Set();

--- a/content/defaultPreferencesLoader.jsm
+++ b/content/defaultPreferencesLoader.jsm
@@ -11,7 +11,9 @@
  */
 
 const { utils: Cu, classes: Cc, interfaces: Ci } = Components;
-const {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm');
+const Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 
 var EXPORTED_SYMBOLS = ['DefaultPreferencesLoader'];
 


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and those code doesn't have to import Services.jsm if the strict_min_version is 101.

And also it's available in all system globals from version 104 https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 , and those code doesn't have to import Services.jsm for recent versions.